### PR TITLE
Update cluster_create.yml to use service module for restart clcomd

### DIFF
--- a/examples/cluster_create.yml
+++ b/examples/cluster_create.yml
@@ -70,20 +70,11 @@
       when: inventory_hostname in groups['node1']
 
   handlers:
-    - name: Stop clcomd # noqa: no-changed-when
-      ansible.builtin.command:
-        cmd: stopsrc -s clcomd
-      ignore_errors: true # noqa: ignore-errors
-      listen: "Restart clcomd"
-
-    - name: Wait 5 seconds...
-      ansible.builtin.pause:
-        seconds: 5
-      listen: "Restart clcomd"
-
-    - name: Start clcomd # noqa: no-changed-when
-      ansible.builtin.command:
-        cmd: startsrc -s clcomd
+    - name: "Restart clcomd"
+      ansible.builtin.service:
+        name: clcomd
+        state: restarted
+        sleep: 5
       listen: "Restart clcomd"
 
     - name: Synchronize cluster


### PR DESCRIPTION
Tested and worked fine with the current Ansible version 2.14.2 from AIX Toolbox.

Improvement as discussed in Issue https://github.com/power-devops/powerha_aix/issues/1